### PR TITLE
added pyopenssl to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.3.0
 termcolor
+pyopenssl


### PR DESCRIPTION
If you don't have pyopenssl you'll get:

urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='127.0.0.1', port=1337): Max retries exceeded with url: /api/admin/login (Caused by S
SLError(SSLError(1, '[SSL: VERSION_TOO_LOW] version too low (_ssl.c:719)'),))