### PR TITLE
fix for invoke_wmi bug

### DIFF
--- a/DeathStar.py
+++ b/DeathStar.py
@@ -539,7 +539,7 @@ def spread(agent_name):
 
             print_info('Starting lateral movement', agent_name)
             if priority_targets:
-                for box in [target for target in priority_targets if target not in domain_controllers]:
+                for box in [target for target in priority_targets]:
                     if not agent_on_host(hostname=box) and find_localadmin_access(agent_name, no_ping=True, computer_name=box):
                         invoke_wmi(agent_name, box)
 


### PR DESCRIPTION
when "priority_targets" includes only domain controller, invoke_wmi gives "required module option missing" error since the code only spreads to non domain controller computers. I removed that condition. Now it works if the domain controller is the only target.

Related issue: https://github.com/byt3bl33d3r/DeathStar/issues/38