### PR TITLE
Fixed all modules with new Empire options and fixed bugs that Empire introduced

### DIFF
--- a/DeathStar.py
+++ b/DeathStar.py
@@ -728,7 +728,7 @@ if __name__ == '__main__':
     args.add_argument('-u', '--username', type=str, default='empireadmin', help='Empire username (default: empireadmin)')
     args.add_argument('-p', '--password', type=str, default='Password123', help='Empire password (default: Password123)')
     args.add_argument('-lip', '--listener-ip', type=str, help='IP for the DeathStar listener (Empire should auto detect the IP, if not use this flag)')
-    args.add_argument('-lp', '--listener-port', type=int, default=8443, metavar='PORT', help='Port to start the DeathStar listener on (default: 8443)')
+    args.add_argument('-lp', '--listener-port', type=int, default=80, metavar='PORT', help='Port to start the DeathStar listener on (default: 8443)')
     args.add_argument('-t', '--threads', type=int, default=20, help='Specifies the number of threads for modules to use (default: 20)')
     args.add_argument('--no-mimikatz', action='store_true', help='Do not use Mimikatz during lateral movement (default: False)')
     args.add_argument('--no-domain-privesc', action='store_true', help='Do not use domain privilege escalation techniques (default: False)')


### PR DESCRIPTION
Added a bunch of code to fix the module_options to fit with latest Empire version. Additionally, added code to handle the bugs that Empire introduced recently, especially as it relates to how Empire handles getting task results. Empire seems to now spit back "Job started: xxxxxx" when you poll the agent for results. Only after the job is done will it actually give the completed results but there's no indication of when the job finished. Most jobs have the string, "Get-XXXXX completed!" at the end of the results string, however, some modules leave off the exclamation mark and others (get_group_members) don't have a completed string at all. Sigh.

Another issue is that some modules in empire return results like, "Job started: XXXXXXwindows10.lab.local\r\nwindows11.lab.local". They're missing the \r\n in between the job started msg and the task results. 

So all that shit's fixed and I tried to fix it so that even when Empire fixes their own bugs in the output and stuff, DeathStar will still work properly. 